### PR TITLE
Update connection controls in status bar

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/bloc_console_widget.dart';
 import '../models/serial_port_info.dart';
 import '../services/serial_port_service.dart' as serial;
 import 'action_history_screen.dart';
+import 'provisioner_connection_screen.dart';
 
 class BlocMainScreen extends StatefulWidget {
   const BlocMainScreen({super.key});
@@ -111,6 +112,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
           appBar: AppBar(
             title: const Text('Bluetooth Mesh Provisioner'),
             backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+            actions: const [],
             bottom: TabBar(
               controller: _tabController,
               tabs: [
@@ -211,14 +213,42 @@ class _BlocMainScreenState extends State<BlocMainScreen>
   }
 
   Widget _buildStatusBar(provisioner.ProvisionerState state) {
+    Color indicatorColor;
+    switch (state.connectionStatus) {
+      case provisioner.ConnectionStatus.connecting:
+        indicatorColor = Colors.orange;
+        break;
+      case provisioner.ConnectionStatus.connected:
+        indicatorColor = Colors.green;
+        break;
+      case provisioner.ConnectionStatus.error:
+        indicatorColor = Colors.red;
+        break;
+      default:
+        indicatorColor = Colors.grey;
+    }
+
     return Container(
       padding: const EdgeInsets.all(8),
       color: Theme.of(context).colorScheme.secondaryContainer,
       child: Row(
         children: [
-          const Icon(Icons.usb, size: 20),
+          IconButton(
+            icon: const Icon(Icons.usb, size: 20),
+            tooltip: 'Connection Settings',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const ProvisionerConnectionScreen(),
+                ),
+              );
+            },
+          ),
           const SizedBox(width: 8),
-          SelectableText(state.connectedPort?.displayName ?? 'Connected'),
+          Text('Provisioner (${state.connectedPort?.portName ?? 'N/A'})'),
+          const SizedBox(width: 8),
+          Icon(Icons.circle, color: indicatorColor, size: 12),
           const Spacer(),
           Chip(
             label: Text('${state.foundUuids.length} new'),

--- a/bluetooth_mesh_hardware_provisioner/lib/screens/provisioner_connection_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/provisioner_connection_screen.dart
@@ -1,0 +1,124 @@
+// lib/screens/provisioner_connection_screen.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../blocs/provisioner_bloc.dart' as provisioner;
+import '../models/serial_port_info.dart';
+import '../services/serial_port_service.dart' as serial;
+
+class ProvisionerConnectionScreen extends StatefulWidget {
+  const ProvisionerConnectionScreen({super.key});
+
+  @override
+  State<ProvisionerConnectionScreen> createState() => _ProvisionerConnectionScreenState();
+}
+
+class _ProvisionerConnectionScreenState extends State<ProvisionerConnectionScreen> {
+  final serial.SerialPortService _service = serial.SerialPortService();
+  List<SerialPortInfo> _ports = [];
+  SerialPortInfo? _selectedPort;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _scanPorts();
+  }
+
+  Future<void> _scanPorts() async {
+    final ports = await _service.scanForPorts();
+    if (!mounted) return;
+    setState(() {
+      _ports = ports;
+      _selectedPort = ports.isNotEmpty ? ports.first : null;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Provisioner Connection'),
+      ),
+      body: BlocBuilder<provisioner.ProvisionerBloc, provisioner.ProvisionerState>(
+        builder: (context, state) {
+          final status = state.connectionStatus;
+          final portName = state.connectedPort?.portName ?? 'N/A';
+          Color indicatorColor;
+          switch (status) {
+            case provisioner.ConnectionStatus.connecting:
+              indicatorColor = Colors.orange;
+              break;
+            case provisioner.ConnectionStatus.connected:
+              indicatorColor = Colors.green;
+              break;
+            case provisioner.ConnectionStatus.error:
+              indicatorColor = Colors.red;
+              break;
+            default:
+              indicatorColor = Colors.grey;
+          }
+
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text('Provisioner ($portName)'),
+                    const SizedBox(width: 8),
+                    Icon(Icons.circle, color: indicatorColor, size: 12),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                if (_loading)
+                  const Center(child: CircularProgressIndicator())
+                else if (_ports.isEmpty)
+                  const Text('No serial ports found')
+                else
+                  DropdownButton<SerialPortInfo>(
+                    value: _selectedPort,
+                    hint: const Text('Select Port'),
+                    items: _ports
+                        .map(
+                          (p) => DropdownMenuItem(
+                            value: p,
+                            child: Text(p.displayName),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (val) => setState(() => _selectedPort = val),
+                  ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    ElevatedButton(
+                      onPressed: status == provisioner.ConnectionStatus.connected
+                          ? null
+                          : _selectedPort == null
+                              ? null
+                              : () => context
+                                  .read<provisioner.ProvisionerBloc>()
+                                  .add(provisioner.ConnectToPort(_selectedPort!)),
+                      child: const Text('Connect'),
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      onPressed: status == provisioner.ConnectionStatus.connected
+                          ? () => context
+                              .read<provisioner.ProvisionerBloc>()
+                              .add(provisioner.Disconnect())
+                          : null,
+                      child: const Text('Disconnect'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- reposition provisioner connection button to the status bar
- show connection port and status indicator next to the new button

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
