### PR TITLE
Resolve merge artifacts in Provisioner BLoC

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -624,25 +624,10 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
     emit(state.copyWith(consoleEntries: entries, currentAction: current));
   }
 
-<<<<<<< HEAD
-  Future<void> _onSendConsoleCommand(SendConsoleCommand event, Emitter<ProvisionerState> emit) async {
-    if (_consoleService == null) return;
-
-    try {
-      // Add command to console
-      add(AddConsoleEntry(event.command, ConsoleEntryType.command));
-
-      // Send raw command
-      await _consoleService!.sendRawCommand(event.command);
-    } catch (e) {
-      add(AddConsoleEntry('Error: $e', ConsoleEntryType.error));
-    }
-=======
   /// Updates the list of discovered node UUIDs when a new node is found.
   void _onNodeDiscovered(NodeDiscovered event, Emitter<ProvisionerState> emit) {
     final updated = Set<String>.from(state.foundUuids)..add(event.uuid);
     emit(state.copyWith(foundUuids: updated));
->>>>>>> origin/main
   }
 
   void _handleIncomingData(String data) {

--- a/bluetooth_mesh_hardware_provisioner/lib/widgets/bloc_console_widget.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/widgets/bloc_console_widget.dart
@@ -31,15 +31,8 @@ class _BlocConsoleWidgetState extends State<BlocConsoleWidget> {
 
     _commandController.clear();
 
-<<<<<<< HEAD
-    // Send command through BLoC
-    context
-        .read<ProvisionerBloc>()
-        .add(SendConsoleCommand(command));
-=======
     // Dispatch the command to the provisioner BLoC.
     context.read<ProvisionerBloc>().add(SendConsoleCommand(command));
->>>>>>> origin/main
   }
 
   void _copyToClipboard(List<ConsoleEntry> entries) {


### PR DESCRIPTION
## Summary
- clean up merge markers in `ProvisionerBloc`
- clean up merge markers in the console widget
- remove stray closing brace

## Testing
- `true`