### PR TITLE
Fix dispose error in command processor

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -291,20 +291,11 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
         }
       });
 
-      // Listen to processed lines for console display
+      // Forward processed lines to the bloc as events so state updates happen
+      // within an event handler. This avoids calling `emit` after this handler
+      // has completed, which would trigger a BLoC assertion.
       _processedLineSubscription = _processor!.lineStream.listen((line) {
-        final entries = List<ConsoleEntry>.from(state.consoleEntries);
-        entries.add(ConsoleEntry(
-          text: line.raw,
-          type: _getConsoleEntryType(line.type),
-        ));
-
-        // Keep only last 1000 entries
-        if (entries.length > 1000) {
-          entries.removeRange(0, entries.length - 1000);
-        }
-
-        emit(state.copyWith(consoleEntries: entries));
+        add(_ProcessedLineReceived(line));
       });
 
       // Listen for node discoveries

--- a/bluetooth_mesh_hardware_provisioner/lib/services/command_processor.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/command_processor.dart
@@ -122,7 +122,6 @@ class CommandProcessor {
   }
 
   void dispose() {
-    _lineTimer?.cancel();
     _dataSubscription?.cancel();
     _lineController.close();
   }


### PR DESCRIPTION
## Summary
- remove call to missing `_lineTimer` in `CommandProcessor.dispose`
- forward processed lines to bloc events to avoid post-handler emit crash

## Testing
- `python3 bluetooth_mesh_hardware_provisioner/generate_fixme.py`