### PR TITLE
Improve subscription UX and status handling

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/main.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/main.dart
@@ -1,4 +1,4 @@
-// lib/main_bloc.dart
+// lib/main.dart
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -21,6 +21,9 @@ class BlocProvisionerApp extends StatelessWidget {
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
           useMaterial3: true,
+          cardTheme: const CardTheme(surfaceTintColor: Colors.transparent),
+          dialogTheme: const DialogTheme(surfaceTintColor: Colors.transparent),
+          appBarTheme: const AppBarTheme(surfaceTintColor: Colors.transparent),
         ),
         darkTheme: ThemeData(
           colorScheme: ColorScheme.fromSeed(
@@ -28,6 +31,9 @@ class BlocProvisionerApp extends StatelessWidget {
             brightness: Brightness.dark,
           ),
           useMaterial3: true,
+          cardTheme: const CardTheme(surfaceTintColor: Colors.transparent),
+          dialogTheme: const DialogTheme(surfaceTintColor: Colors.transparent),
+          appBarTheme: const AppBarTheme(surfaceTintColor: Colors.transparent),
         ),
         debugShowCheckedModeBanner: false,
         home: const BlocMainScreen(),


### PR DESCRIPTION
## Summary
- keep command status visible until next command
- flatten Material design surfaces for a cleaner look
- show current subscriptions at the top with an add button
- add device selection dialog for linking subscriptions
- validate device labels (no spaces, 32 char limit)
- remove obsolete physical identify option

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c14c15b908325b554eff12375efba