### PR TITLE
Fix Flutter theme type mismatch

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/main.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/main.dart
@@ -21,8 +21,8 @@ class BlocProvisionerApp extends StatelessWidget {
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
           useMaterial3: true,
-          cardTheme: const CardTheme(surfaceTintColor: Colors.transparent),
-          dialogTheme: const DialogTheme(surfaceTintColor: Colors.transparent),
+          cardTheme: const CardThemeData(surfaceTintColor: Colors.transparent),
+          dialogTheme: const DialogThemeData(surfaceTintColor: Colors.transparent),
           appBarTheme: const AppBarTheme(surfaceTintColor: Colors.transparent),
         ),
         darkTheme: ThemeData(
@@ -31,8 +31,8 @@ class BlocProvisionerApp extends StatelessWidget {
             brightness: Brightness.dark,
           ),
           useMaterial3: true,
-          cardTheme: const CardTheme(surfaceTintColor: Colors.transparent),
-          dialogTheme: const DialogTheme(surfaceTintColor: Colors.transparent),
+          cardTheme: const CardThemeData(surfaceTintColor: Colors.transparent),
+          dialogTheme: const DialogThemeData(surfaceTintColor: Colors.transparent),
           appBarTheme: const AppBarTheme(surfaceTintColor: Colors.transparent),
         ),
         debugShowCheckedModeBanner: false,


### PR DESCRIPTION
## Summary
- update theme config in `BlocProvisionerApp` to use CardThemeData and DialogThemeData

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c18700ab083259bf12ecf80da563b