### PR TITLE
Switch linking identify to DALI command

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -2092,7 +2092,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                       tooltip: 'Identify',
                       onPressed: () => _executeCommand(
                         context,
-                        'mesh/device/identify/set ${d.addressHex} 5 3000',
+                        'mesh/dali_lc/identify/set ${d.addressHex} 5 3000',
                         stateKey: 'identify_set_${d.address}',
                       ),
                     ),


### PR DESCRIPTION
## Summary
- use DALI identify command when linking devices

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2869e6ac832590bebbe8023f212d