### PR TITLE
Fix device reset command

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -70,8 +70,8 @@ All commands must be prefixed with `mesh/`.
 - `mesh/provision/status/get` - Get provisioning state
 - `mesh/provision/last_addr/get` - Get the last assigned address
 
-### Device Commands
-- `mesh/device/reset {node_addr}` - Reset and unprovision a node
+-### Device Commands
+- `mesh/device/reset {node_addr} {timeout}` - Reset and unprovision a node
 - `mesh/device/remove {node_addr}` - Remove a node from the local DB
 - `mesh/device/label/get {node_addr}` - Fetch the node's label
 - `mesh/device/label/set {node_addr} {label}` - Set a label for the node

--- a/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
@@ -203,7 +203,8 @@ Future<List<MeshDevice>> getProvisionedDevices() async {
 
   /// Reset (unprovision) a device
   Future<bool> resetDevice(int address) async {
-    final result = await executeCommand('mesh/device/reset 0x${address.toRadixString(16)}');
+    final result =
+        await executeCommand('mesh/device/reset 0x${address.toRadixString(16)} 3000');
     return result.success;
   }
 


### PR DESCRIPTION
## Summary
- ensure resetting a node uses `mesh/device/reset` with timeout
- document the timeout parameter in README

## Testing
- `dart format bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart bluetooth_mesh_hardware_provisioner/README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c28f05d588325ac70c4b177bd3dd7