### PR TITLE
Fix device removal logic

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -2052,16 +2052,10 @@ class _BlocMainScreenState extends State<BlocMainScreen>
       if (action == 'reset') {
         context.read<provisioner.ProvisionerBloc>().add(provisioner.UnprovisionDevice(device));
       } else if (action == 'remove') {
-        // Just remove from database without resetting the device
+        // Remove the device from the database
         context.read<provisioner.ProvisionerBloc>().add(
-          provisioner.SendConsoleCommand('mesh/device/remove 0x${device.address.toRadixString(16)}'),
+          provisioner.RemoveDeviceFromDb(device),
         );
-        // Refresh list after removal
-        Future.delayed(const Duration(milliseconds: 500), () {
-          if (mounted) {
-            context.read<provisioner.ProvisionerBloc>().add(provisioner.RefreshDeviceList());
-          }
-        });
       }
     }
   }

--- a/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
@@ -208,6 +208,13 @@ Future<List<MeshDevice>> getProvisionedDevices() async {
     return result.success;
   }
 
+  /// Remove a device from the provisioner's database.
+  Future<bool> removeDevice(int address) async {
+    final result =
+        await executeCommand('mesh/device/remove 0x${address.toRadixString(16)}');
+    return result.success;
+  }
+
   /// Add group subscription
   Future<bool> addSubscription(int nodeAddr, int groupAddr) async {
     final result = await executeCommand(


### PR DESCRIPTION
## Summary
- add `removeDevice` command in `MeshCommandService`
- handle new `RemoveDeviceFromDb` event in `ProvisionerBloc`
- update UI to dispatch the new event when removing a device

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcafccfb08325aa84f3e5760ff134