### PR TITLE
Add slider widgets for device configuration

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -31,6 +31,7 @@ A comprehensive Flutter application for provisioning and managing Bluetooth mesh
 - Subscribe address management
 - Publish configuration
 - Health status monitoring
+- Intuitive sliders for configuring idle, trigger, override and radar settings
 
 ### 💻 Console Interface
 - Raw command input for advanced users

--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -7,6 +7,7 @@ import '../blocs/provisioner_bloc.dart' as provisioner;
 import '../protocols/rtm_console_protocol.dart';
 import '../widgets/error_notification.dart';
 import '../widgets/bloc_console_widget.dart';
+import '../widgets/slider_input.dart';
 import '../models/serial_port_info.dart';
 import '../models/mesh_device.dart';
 import '../services/serial_port_service.dart' as serial;
@@ -1517,30 +1518,32 @@ class _BlocMainScreenState extends State<BlocMainScreen>
 
     final result = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('DALI Idle Configuration'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: arcController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(
-                labelText: 'Idle Arc Level',
-                hintText: '0-254',
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('DALI Idle Configuration'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Idle arc level defines the light level when no trigger is active.\n'
+                'Fade time controls how quickly the light transitions back to this level.',
               ),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: fadeController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(
-                labelText: 'Fade Time',
-                hintText: '0-30 (see fade time table)',
+              const SizedBox(height: 16),
+              SliderInput(
+                label: 'Idle Arc Level',
+                min: 0,
+                max: 254,
+                controller: arcController,
               ),
-            ),
-          ],
-        ),
+              const SizedBox(height: 16),
+              SliderInput(
+                label: 'Fade Time',
+                min: 0,
+                max: 30,
+                controller: fadeController,
+              ),
+            ],
+          ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext),
@@ -1569,50 +1572,50 @@ class _BlocMainScreenState extends State<BlocMainScreen>
 
     final result = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('DALI Trigger Configuration'),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: arcController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Trigger Arc Level',
-                  hintText: '0-254',
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('DALI Trigger Configuration'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Trigger settings control how the light behaves when activated.'
+                  '\nArc level is the brightness on trigger, fade in/out define the '
+                  'transition durations, and hold time sets how long the trigger level '
+                  'stays active.',
                 ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: fadeInController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Fade In Time',
-                  hintText: '0-30',
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Trigger Arc Level',
+                  min: 0,
+                  max: 254,
+                  controller: arcController,
                 ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: fadeOutController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Fade Out Time',
-                  hintText: '0-30',
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Fade In Time',
+                  min: 0,
+                  max: 30,
+                  controller: fadeInController,
                 ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: holdTimeController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Hold Time (seconds)',
-                  hintText: '0-65535',
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Fade Out Time',
+                  min: 0,
+                  max: 30,
+                  controller: fadeOutController,
                 ),
-              ),
-            ],
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Hold Time (seconds)',
+                  min: 0,
+                  max: 65535,
+                  controller: holdTimeController,
+                ),
+              ],
+            ),
           ),
-        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext),
@@ -1683,39 +1686,39 @@ class _BlocMainScreenState extends State<BlocMainScreen>
 
     final result = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('DALI Manual Override'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: arcController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(
-                labelText: 'Arc Level',
-                hintText: '0-254',
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('DALI Manual Override'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Override temporarily forces the light to a specific level.'
+                '\nDuration defines how long the override is active.',
               ),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: fadeController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(
-                labelText: 'Fade Time',
-                hintText: '0-30',
+              const SizedBox(height: 16),
+              SliderInput(
+                label: 'Arc Level',
+                min: 0,
+                max: 254,
+                controller: arcController,
               ),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: durationController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(
-                labelText: 'Duration',
-                hintText: '0=off, 1-65534=seconds, 65535=until reboot',
+              const SizedBox(height: 16),
+              SliderInput(
+                label: 'Fade Time',
+                min: 0,
+                max: 30,
+                controller: fadeController,
               ),
-            ),
-          ],
-        ),
+              const SizedBox(height: 16),
+              SliderInput(
+                label: 'Duration',
+                min: 0,
+                max: 65535,
+                controller: durationController,
+              ),
+            ],
+          ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext),
@@ -1745,50 +1748,50 @@ class _BlocMainScreenState extends State<BlocMainScreen>
 
     final result = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Radar Configuration'),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: bandController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Threshold Band (mV)',
-                  hintText: '0-1650',
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Radar Configuration'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Radar parameters tune the motion sensor. Adjust the threshold '
+                  'band to set sensitivity, cross count for detection confidence, '
+                  'sample interval for polling rate, and buffer depth for history '
+                  'size.',
                 ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: crossController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Cross Count Threshold',
-                  hintText: '1-500',
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Threshold Band (mV)',
+                  min: 0,
+                  max: 1650,
+                  controller: bandController,
                 ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: intervalController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Sample Interval (ms)',
-                  hintText: '1-2047',
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Cross Count Threshold',
+                  min: 1,
+                  max: 500,
+                  controller: crossController,
                 ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: depthController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Buffer Depth',
-                  hintText: '0-500',
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Sample Interval (ms)',
+                  min: 1,
+                  max: 2047,
+                  controller: intervalController,
                 ),
-              ),
-            ],
+                const SizedBox(height: 16),
+                SliderInput(
+                  label: 'Buffer Depth',
+                  min: 0,
+                  max: 500,
+                  controller: depthController,
+                ),
+              ],
+            ),
           ),
-        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext),

--- a/bluetooth_mesh_hardware_provisioner/lib/widgets/slider_input.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/widgets/slider_input.dart
@@ -1,0 +1,69 @@
+// lib/widgets/slider_input.dart
+
+import 'package:flutter/material.dart';
+
+/// Combines a numeric text field with a slider.
+/// The slider updates the text field as it moves.
+class SliderInput extends StatefulWidget {
+  final String label;
+  final int min;
+  final int max;
+  final TextEditingController controller;
+
+  const SliderInput({
+    super.key,
+    required this.label,
+    required this.min,
+    required this.max,
+    required this.controller,
+  });
+
+  @override
+  State<SliderInput> createState() => _SliderInputState();
+}
+
+class _SliderInputState extends State<SliderInput> {
+  late double _value;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = double.tryParse(widget.controller.text) ?? widget.min.toDouble();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextField(
+          controller: widget.controller,
+          keyboardType: TextInputType.number,
+          decoration: InputDecoration(
+            labelText: widget.label,
+            hintText: '${widget.min}-${widget.max}',
+          ),
+          onChanged: (text) {
+            final v = double.tryParse(text);
+            if (v != null) {
+              setState(() => _value = v.clamp(widget.min.toDouble(), widget.max.toDouble()));
+            }
+          },
+        ),
+        Slider(
+          min: widget.min.toDouble(),
+          max: widget.max.toDouble(),
+          divisions: widget.max - widget.min,
+          value: _value.clamp(widget.min.toDouble(), widget.max.toDouble()),
+          label: _value.round().toString(),
+          onChanged: (val) {
+            setState(() {
+              _value = val;
+              widget.controller.text = val.round().toString();
+            });
+          },
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SliderInput` widget for numeric sliders synced with text fields
- enhance DALI and radar configuration dialogs with explanations and sliders
- document slider-based configuration in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcb43abc48325bac378846bbdb941