### PR TITLE
Fix status indicator DataCell usage

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -704,7 +704,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                 ],
                 rows: state.provisionedDevices.map((device) {
                   return DataRow(cells: [
-                    DataCell(_buildStatusIndicator(device)),
+                    _buildStatusIndicator(device),
                     DataCell(
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -801,7 +801,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                       ],
                       rows: [
                         DataRow(cells: [
-                          DataCell(_buildStatusIndicator(device)),
+                          _buildStatusIndicator(device),
                           _buildCopyableCell('Address', device.addressHex),
                           _buildCopyableCell('Group Address', device.groupAddressHex),
                           _buildCopyableCell('UUID', device.uuid),


### PR DESCRIPTION
## Summary
- fix `DataCell` being passed into `DataCell` constructors in main screen

## Testing
- `dart format lib/screens/main_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851316789448325b90fbadd6f0d3232