### PR TITLE
Add auto provisioning and provision all

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -17,6 +17,8 @@ A comprehensive Flutter application for provisioning and managing Bluetooth mesh
 - View provisioned nodes in the network
 - Real-time device status updates
 - Support for provisioning and unprovisioning devices
+- Sequential "Provision All" for unprovisioned nodes
+- Optional auto-provisioning of newly discovered devices
 
 ### 🕸️ Network Visualization
 - Interactive 2D mesh network topology view

--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -543,6 +543,27 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                   style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
                 const Spacer(),
+                Row(
+                  children: [
+                    Checkbox(
+                      value: state.autoProvision,
+                      onChanged: (v) => context
+                          .read<provisioner.ProvisionerBloc>()
+                          .add(provisioner.ToggleAutoProvision(v ?? false)),
+                    ),
+                    const Text('Auto Provision'),
+                  ],
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: state.isProvisioning || state.foundUuids.isEmpty
+                      ? null
+                      : () => context
+                          .read<provisioner.ProvisionerBloc>()
+                          .add(provisioner.ProvisionAll()),
+                  child: const Text('Provision All'),
+                ),
+                const SizedBox(width: 8),
                 Text(
                   '${state.foundUuids.length} devices',
                   style: Theme.of(context).textTheme.bodySmall,


### PR DESCRIPTION
## Summary
- support provisioning all discovered nodes sequentially
- introduce optional auto provision feature
- refresh docs for new provisioning capabilities

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685139a388588325bd6cf18e204090f3