### PR TITLE
Fix auto provisioning flow and UI tweaks

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -389,6 +389,10 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
         (_) => add(RefreshDeviceList()),
       );
 
+      if (state.autoProvision || _provisionQueue.isNotEmpty) {
+        add(_ProcessNextProvision());
+      }
+
     } catch (e) {
       emit(state.copyWith(
         connectionStatus: ConnectionStatus.error,
@@ -412,7 +416,9 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
     await _serialService.disconnect();
 
     _knownDeviceAddresses.clear();
-    _provisionQueue.clear();
+      // Preserve the auto-provisioning queue so provisioning can resume after
+      // a reconnect. Clearing it here caused auto provisioning to halt if the
+      // device temporarily disconnected during provisioning.
 
     emit(ProvisionerState(provisionedDevices: state.provisionedDevices));
   }

--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -627,16 +627,6 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                     )),
                     DataCell(Row(
                       children: [
-                        OutlinedButton(
-                          onPressed: () {
-                            context
-                                .read<provisioner.ProvisionerBloc>()
-                                .add(provisioner.SendConsoleCommand(
-                                    'mesh/device/identify $uuid'));
-                          },
-                          child: const Text('Identify'),
-                        ),
-                        const SizedBox(width: 8),
                         FilledButton(
                           onPressed: state.isProvisioning &&
                                   state.provisioningUuid == uuid
@@ -727,28 +717,31 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                   return DataRow(cells: [
                     _buildStatusIndicator(device),
                     DataCell(
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            device.addressHex,
-                            style: const TextStyle(fontFamily: 'monospace'),
-                          ),
-                          if (device.label != null) Text(device.label!),
-                        ],
+                      SizedBox(
+                        width: 90,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              device.addressHex,
+                              style: const TextStyle(fontFamily: 'monospace'),
+                            ),
+                            if (device.label != null) Text(device.label!),
+                          ],
+                        ),
                       ),
                       onTap: () {
                         context.read<provisioner.ProvisionerBloc>().add(provisioner.SelectDevice(device));
                         _tabController.animateTo(1);
                       },
                     ),
-                    DataCell(
-                      SelectableText(device.groupAddressHex),
-                      onTap: () => _showGroupDevicesDialog(context, device.groupAddress),
-                    ),
                     DataCell(SizedBox(
-                      width: 160,
+                      width: 80,
+                      child: SelectableText(device.groupAddressHex),
+                    ), onTap: () => _showGroupDevicesDialog(context, device.groupAddress)),
+                    DataCell(SizedBox(
+                      width: 200,
                       child: SelectableText(
                         device.uuid,
                         maxLines: 1,

--- a/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
@@ -236,7 +236,7 @@ Future<List<MeshDevice>> getProvisionedDevices() async {
   /// Add group subscription
   Future<bool> addSubscription(int nodeAddr, int groupAddr) async {
     final result = await executeCommand(
-      'mesh/device/sub/add 0x${nodeAddr.toRadixString(16)} 0x${groupAddr.toRadixString(16)}'
+      'mesh/device/sub/add 0x${nodeAddr.toRadixString(16)} 0x${groupAddr.toRadixString(16)} 3000'
     );
     return result.success;
   }
@@ -244,7 +244,7 @@ Future<List<MeshDevice>> getProvisionedDevices() async {
   /// Remove group subscription
   Future<bool> removeSubscription(int nodeAddr, int groupAddr) async {
     final result = await executeCommand(
-      'mesh/device/sub/remove 0x${nodeAddr.toRadixString(16)} 0x${groupAddr.toRadixString(16)}'
+      'mesh/device/sub/remove 0x${nodeAddr.toRadixString(16)} 0x${groupAddr.toRadixString(16)} 3000'
     );
     return result.success;
   }


### PR DESCRIPTION
## Summary
- keep provisioning queue on disconnect to ensure auto-provision resumes
- resume queued provisioning after reconnect
- include timeout when modifying subscriptions
- resize device table columns and widen UUID field
- remove unused identify button

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685150b9a70883258328318fbd10851a