### PR TITLE
Center action headers

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -597,7 +597,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                 columnSpacing: 12,
                 columns: const [
                   DataColumn(label: Text('UUID')),
-                  DataColumn(label: Text('Actions')),
+                  DataColumn(label: Center(child: Text('Actions'))),
                 ],
                 rows: state.foundUuids.map((uuid) {
                   return DataRow(cells: [
@@ -710,7 +710,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                   DataColumn(label: Text('Device')),
                   DataColumn(label: Text('Group')),
                   DataColumn(label: Text('UUID')),
-                  DataColumn(label: Text('Actions')),
+                  DataColumn(label: Center(child: Text('Actions'))),
                 ],
                 rows: state.provisionedDevices.map((device) {
                   return DataRow(cells: [


### PR DESCRIPTION
## Summary
- center the **Actions** headers in device tables

## Testing
- `flutter format lib/screens/main_screen.dart` *(fails: `flutter: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68515a86958483259f93b0d85d0e0fb7