### PR TITLE
Implement multi-select subscription dialog

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -31,6 +31,7 @@ A comprehensive Flutter application for provisioning and managing Bluetooth mesh
 - Detailed device information display
 - Model configuration viewing (SIG and Vendor models)
 - Subscribe address management
+- Multi-select subscription dialog with optional self-subscription
 - Publish configuration
 - Health status monitoring
 - Intuitive sliders for configuring idle, trigger, override and radar settings


### PR DESCRIPTION
## Summary
- allow selecting multiple devices for subscriptions
- add self-subscription option in the UI
- document the new multi-select feature

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685162f50da88325ad0d323e842524e2