### PR TITLE
Fix serial port crash on read error

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/services/serial_port_service.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/serial_port_service.dart
@@ -107,7 +107,8 @@ class SerialPortService {
           onError: (error) {
             print('Serial read error: $error');
             _statusController?.add(SerialConnectionStatus.error);
-            // Don't disconnect on read errors - let the user decide
+            // Close the port on read errors to avoid native library crashes
+            disconnect();
           },
           onDone: () {
             print('Serial port closed');


### PR DESCRIPTION
## Summary
- handle read errors by closing the serial port

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851632e3e8c83259827160c09a237f9