### PR TITLE
Handle sequential subscription addition

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -2337,9 +2337,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
     );
 
     if (result != null && mounted) {
-      for (final group in result) {
-        bloc.add(provisioner.AddSubscription(device.address, group));
-      }
+      bloc.add(provisioner.AddSubscriptions(device.address, result));
     }
   }
 


### PR DESCRIPTION
## Summary
- add `AddSubscriptions` event
- sequentially process subscription list in bloc
- dispatch batch subscription event from dialog
- await auto-added subscription after provisioning

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517745299c8325b3df4f643dbe3c1e