### PR TITLE
Fix hold time range and slider hint

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/Neptune Provisioner commands.md
+++ b/bluetooth_mesh_hardware_provisioner/Neptune Provisioner commands.md
@@ -1,3 +1,5 @@
+<!-- bluetooth_mesh_hardware_provisioner/Neptune Provisioner commands.md -->
+
 ```
 ~>_____mesh/
 ~>   |_ factory_reset
@@ -422,7 +424,7 @@ mesh/dali_lc/idle_cfg/get 3 3000
 2. **Arc level** (0..254): The arc level of that the driver should take in the idle state.
 3. **Fade in time**: The time it takes for the light to reach the trigger arc level when in the trigger LC state.
 4. **Fade out time**: The time it takes for the light to reach the idle arc level when leaving the trigger LC state.
-5. **Hold time** (0..65535): The time in seconds the device remains in the trigger state since the last received trigger. Hold time 0 means that triggers get ignored.
+5. **Hold time** (0..65535): The time in seconds the device remains in the trigger state since the last received trigger. Hold time 0 means that triggers get ignored. Sliders in the UI are capped at 120 seconds for easier manipulation.
 6. **Timeout**: Timeout in milliseconds.
 
 >[!tip] About timeouts

--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -1685,6 +1685,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                     label: 'Hold Time (seconds)',
                     min: 0,
                     max: 65535,
+                    sliderMax: 120,
                     controller: holdTimeController,
                   ),
                 ],

--- a/bluetooth_mesh_hardware_provisioner/lib/widgets/slider_input.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/widgets/slider_input.dart
@@ -8,15 +8,22 @@ class SliderInput extends StatefulWidget {
   final String label;
   final int min;
   final int max;
+  final int sliderMax;
   final TextEditingController controller;
 
+  /// Creates a [SliderInput].
+  ///
+  /// [min] and [max] define the valid range for the text input field while
+  /// [sliderMax] controls the maximum value of the slider itself. When
+  /// [sliderMax] is not provided it defaults to [max].
   const SliderInput({
     super.key,
     required this.label,
     required this.min,
     required this.max,
     required this.controller,
-  });
+    int? sliderMax,
+  }) : sliderMax = sliderMax ?? max;
 
   @override
   State<SliderInput> createState() => _SliderInputState();
@@ -28,7 +35,8 @@ class _SliderInputState extends State<SliderInput> {
   @override
   void initState() {
     super.initState();
-    _value = double.tryParse(widget.controller.text) ?? widget.min.toDouble();
+    _value = (double.tryParse(widget.controller.text) ?? widget.min.toDouble())
+        .clamp(widget.min.toDouble(), widget.sliderMax.toDouble());
   }
 
   @override
@@ -49,16 +57,17 @@ class _SliderInputState extends State<SliderInput> {
             onChanged: (text) {
               final v = double.tryParse(text);
               if (v != null) {
-                setState(() =>
-                    _value = v.clamp(widget.min.toDouble(), widget.max.toDouble()));
+                setState(() => _value =
+                    v.clamp(widget.min.toDouble(), widget.sliderMax.toDouble()));
               }
             },
           ),
           Slider(
             min: widget.min.toDouble(),
-            max: widget.max.toDouble(),
-            divisions: widget.max - widget.min,
-            value: _value.clamp(widget.min.toDouble(), widget.max.toDouble()),
+            max: widget.sliderMax.toDouble(),
+            divisions: widget.sliderMax - widget.min,
+            value:
+                _value.clamp(widget.min.toDouble(), widget.sliderMax.toDouble()),
             label: _value.round().toString(),
             onChanged: (val) {
               setState(() {


### PR DESCRIPTION
## Summary
- make SliderInput accept a separate sliderMax to keep full input range
- show hold time limit as 0-65535 again in the trigger config dialog
- note slider limit in commands guide

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525cb838888325b2931a24374f7643