### PR TITLE
Implement periodic scanning

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -316,6 +316,8 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
   Timer? _deviceListTimer;
   /// Timer that periodically verifies the provisioner connection.
   Timer? _healthCheckTimer;
+  /// Timer that periodically scans for unprovisioned nodes.
+  Timer? _scanTimer;
 
   /// Addresses of devices that have been seen in at least one device list call.
   final Set<int> _knownDeviceAddresses = {};
@@ -408,6 +410,13 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
         (_) => add(RefreshDeviceList()),
       );
 
+      // Start periodic scanning for unprovisioned nodes
+      _scanTimer?.cancel();
+      _scanTimer = Timer.periodic(
+        const Duration(seconds: 15),
+        (_) => add(ScanDevices()),
+      );
+
       // Start periodic health checks
       _healthCheckTimer?.cancel();
       _healthCheckTimer = Timer.periodic(
@@ -437,6 +446,7 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
     _provisioningTimer?.cancel();
     _deviceListTimer?.cancel();
     _healthCheckTimer?.cancel();
+    _scanTimer?.cancel();
 
     _meshService?.dispose();
     _processor?.dispose();
@@ -1159,6 +1169,7 @@ void _onProcessedLineReceived(_ProcessedLineReceived event, Emitter<ProvisionerS
     _provisioningTimer?.cancel();
     _deviceListTimer?.cancel();
     _healthCheckTimer?.cancel();
+    _scanTimer?.cancel();
 
     _meshService?.dispose();
     _processor?.dispose();


### PR DESCRIPTION
## Summary
- refresh device lists automatically
- scan for unprovisioned nodes periodically

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d8fe42d88325badc7ba6b1896bf3