### PR TITLE
Add group column linking

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -32,6 +32,7 @@ A comprehensive Flutter application for provisioning and managing Bluetooth mesh
 - Model configuration viewing (SIG and Vendor models)
 - Subscribe address management
 - Multi-select subscription dialog with optional self-subscription
+- Quick linking to devices directly from the group column
 - Publish configuration
 - Health status monitoring
 - Intuitive sliders for configuring idle, trigger, override and radar settings

--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -722,10 +722,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                         _tabController.animateTo(1);
                       },
                     ),
-                    DataCell(SizedBox(
-                      width: 80,
-                      child: SelectableText(device.groupAddressHex),
-                    ), onTap: () => _showGroupDevicesDialog(context, device.groupAddress)),
+                    _buildGroupCell(device),
                     DataCell(SizedBox(
                       width: 200,
                       child: SelectableText(
@@ -2124,6 +2121,33 @@ class _BlocMainScreenState extends State<BlocMainScreen>
       height: 12,
       decoration: BoxDecoration(color: color, shape: BoxShape.circle),
     ));
+  }
+
+  /// Display the group address with an option to link the device to others.
+  DataCell _buildGroupCell(MeshDevice device) {
+    return DataCell(
+      SizedBox(
+        width: 100,
+        child: Row(
+          children: [
+            Expanded(
+              child: SelectableText(
+                device.groupAddressHex,
+                style: const TextStyle(fontFamily: 'monospace'),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.link, size: 16),
+              tooltip: 'Link device',
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+              onPressed: () => _showAddSubscriptionDialog(context, device),
+            ),
+          ],
+        ),
+      ),
+      onTap: () => _showGroupDevicesDialog(context, device.groupAddress),
+    );
   }
 
   DataCell _buildCopyableCell(String label, String value) {


### PR DESCRIPTION
## Summary
- show link icon in group column on device overview
- mention quick linking in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cd0d576c83259f1e61a81b405b85