### PR TITLE
Add quick device action buttons

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -35,6 +35,7 @@ A comprehensive Flutter application for provisioning and managing Bluetooth mesh
 - Publish configuration
 - Health status monitoring
 - Intuitive sliders for configuring idle, trigger, override and radar settings
+- Quick action buttons for identify, override toggle and radar sensitivity presets
 
 ### 💻 Console Interface
 - Raw command input for advanced users


### PR DESCRIPTION
## Summary
- add quick identify, override, and radar sensitivity actions in device list
- track override state per device
- mention quick action buttons in README

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cdf40ff083258ea7917a8526ed91