### PR TITLE
Fix device list clearing

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
@@ -171,12 +171,15 @@ class MeshCommandService {
     return uuids;
   }
 
-/// Get list of provisioned devices
-Future<List<MeshDevice>> getProvisionedDevices() async {
+/// Get list of provisioned devices.
+///
+/// Returns `null` if the command fails so callers can decide
+/// whether to keep the existing list or handle the error.
+Future<List<MeshDevice>?> getProvisionedDevices() async {
   final result = await executeCommand('mesh/device/list');
 
   if (!result.success) {
-    return [];
+    return null;
   }
 
   // Parse device list


### PR DESCRIPTION
## Summary
- avoid clearing provisioned device list when refresh fails
- return `null` when fetching device list fails

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d43ca9a88325b234d5c3d9c00783