### PR TITLE
Add group linking management

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -1210,6 +1210,19 @@ void _onProcessedLineReceived(_ProcessedLineReceived event, Emitter<ProvisionerS
     }
   }
 
+  /// Fetch the list of group subscriptions for [address].
+  ///
+  /// Returns an empty list if the provisioner is not connected or the
+  /// command fails.
+  Future<List<int>> fetchSubscriptions(int address) async {
+    if (_meshService == null) return [];
+    try {
+      return await _meshService!.getSubscriptions(address);
+    } catch (_) {
+      return [];
+    }
+  }
+
   @override
   Future<void> close() {
     _serialStatusSubscription?.cancel();


### PR DESCRIPTION
## Summary
- allow fetching subscriptions in `ProvisionerBloc`
- let group cell open link manager instead of list dialog
- add dialog for managing device links

## Testing
- `dart format` *(fails: `bash: dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853d5a8cc7c8325835d46f1d053de67