### PR TITLE
Fix missing pendingSetLabels map

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -44,6 +44,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
   final Map<String, CommandState> _commandStates = {};
   final Map<String, String> _commandResults = {};
   final Map<String, String> _pendingGets = {};
+  final Map<String, String> _pendingSetLabels = {};
   List<int> _lastSubscriptions = [];
   final Map<int, bool> _overrideStates = {};
 


### PR DESCRIPTION
## Summary
- define `_pendingSetLabels` map in main screen state

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d954337083258bfb986615a08406