### PR TITLE
Fix clickable area in device table

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -724,8 +724,9 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                   return DataRow(cells: [
                     _buildStatusIndicator(device),
                     DataCell(
-                      SizedBox(
-                        width: 90,
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(vertical: 8),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           mainAxisSize: MainAxisSize.min,
@@ -2283,9 +2284,10 @@ class _BlocMainScreenState extends State<BlocMainScreen>
   /// Display the group address and open the link management dialog on tap.
   DataCell _buildGroupCell(MeshDevice device) {
     return DataCell(
-      SizedBox(
-        width: 100,
-        child: SelectableText(
+      Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Text(
           device.groupAddressHex,
           style: const TextStyle(fontFamily: 'monospace'),
         ),


### PR DESCRIPTION
## Summary
- expand width of device address cell to make it fully tappable
- show group address in a container so the entire cell reacts on tap

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e00842988325b143869b8f32a9bf