### PR TITLE
Implement radar sensitivity presets

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -2106,9 +2106,17 @@ class _BlocMainScreenState extends State<BlocMainScreen>
 
     if (selection != null && mounted) {
       final band = (1650 * selection / 100).round();
+      const crossCounts = {
+        10: 47,
+        25: 118,
+        50: 235,
+        75: 352,
+        100: 30,
+      };
+      final cross = crossCounts[selection] ?? 31;
       _executeCommand(
         context,
-        'mesh/radar/cfg/set ${device.addressHex} $band 31 5 500 3000',
+        'mesh/radar/cfg/set ${device.addressHex} $band $cross 5 500 3000',
         stateKey: 'radar_quick_${device.address}',
       );
     }


### PR DESCRIPTION
## Summary
- map radar sensitivity presets to specific cross count thresholds

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e311d9848325aff7af68bacd6a5f