### PR TITLE
Update override icon in main screen

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart
@@ -771,7 +771,7 @@ class _BlocMainScreenState extends State<BlocMainScreen>
                         IconButton(
                           icon: Icon(
                             _overrideStates[device.address] ?? false
-                                ? Icons.lightbulb
+                                ? Icons.wb_incandescent
                                 : Icons.lightbulb_outline,
                           ),
                           tooltip: 'Override',


### PR DESCRIPTION
## Summary
- use `Icons.wb_incandescent` when override is active so the icon shows light rays

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format bluetooth_mesh_hardware_provisioner/lib/screens/main_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e5df4f74832597783e3afc53dbc2