### PR TITLE
Implement default config after provisioning

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -36,6 +36,7 @@ A comprehensive Flutter application for provisioning and managing Bluetooth mesh
 - Display all subscribed groups in the device list with the node's own group in **bold** when multiple groups are present
 - Publish configuration
 - Health status monitoring
+- Automatic configuration of default idle and trigger settings after provisioning
 - Intuitive sliders for configuring idle, trigger, override and radar settings
 - Quick action buttons for identify, override toggle and radar sensitivity presets
 

--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import '../models/serial_port_info.dart';
 import '../models/mesh_device.dart';
 import '../models/dali_lc.dart';
+import '../models/fade_time.dart';
 import '../models/radar_info.dart';
 import '../services/serial_port_service.dart';
 import '../services/command_processor.dart';
@@ -1073,6 +1074,22 @@ void _onProcessedLineReceived(_ProcessedLineReceived event, Emitter<ProvisionerS
       }
       if (newDevice != null) {
         add(AddSubscription(newDevice.address, newDevice.groupAddress));
+
+        // Apply default DALI LC configuration
+        try {
+          await _meshService!.setDaliIdleConfig(
+            newDevice.address,
+            0,
+            FadeTime.twoSeconds,
+          );
+          await _meshService!.setDaliTriggerConfig(
+            newDevice.address,
+            254,
+            FadeTime.zero,
+            FadeTime.sixSeconds,
+            5,
+          );
+        } catch (_) {}
       }
 
       // Do another refresh to ensure we have the latest data

--- a/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/mesh_command_service.dart
@@ -330,6 +330,22 @@ Future<List<MeshDevice>?> getProvisionedDevices() async {
     );
   }
 
+  /// Set the DALI LC idle configuration.
+  Future<bool> setDaliIdleConfig(
+      int address, int arc, FadeTime fade) async {
+    final result = await executeCommand(
+        'mesh/dali_lc/idle_cfg/set $address $arc ${fade.value} 3000');
+    return result.success;
+  }
+
+  /// Set the DALI LC trigger configuration.
+  Future<bool> setDaliTriggerConfig(
+      int address, int arc, FadeTime fadeIn, FadeTime fadeOut, int hold) async {
+    final result = await executeCommand(
+        'mesh/dali_lc/trigger_cfg/set $address $arc ${fadeIn.value} ${fadeOut.value} $hold 3000');
+    return result.success;
+  }
+
   /// Get the remaining DALI LC identify time in seconds.
   Future<int?> getDaliIdentifyTime(int address) async {
     final result =


### PR DESCRIPTION
## Summary
- automatically configure default idle/trigger settings after provisioning
- expose helper methods in `MeshCommandService` for setting DALI configs
- document automatic config in README

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e35d8b1883258c151c3cf269e1f3