### PR TITLE
Fix extraneous brace in provisioner bloc

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -1272,7 +1272,6 @@ void _onProcessedLineReceived(_ProcessedLineReceived event, Emitter<ProvisionerS
 
     return result;
   }
-  }
 
   @override
   Future<void> close() {


### PR DESCRIPTION
## Summary
- fix stray closing brace in `provisioner_bloc.dart`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f9a35a288325b1865e777dcea952