### PR TITLE
Filter out Zephyr log output

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/README.md
+++ b/bluetooth_mesh_hardware_provisioner/README.md
@@ -46,6 +46,7 @@ A comprehensive Flutter application for provisioning and managing Bluetooth mesh
 - Command history
 - Bidirectional communication monitoring
 - Optional auto-scroll toggle
+- Only lines starting with `~>` are processed to avoid Zephyr log noise
 
 ## Architecture
 

--- a/bluetooth_mesh_hardware_provisioner/lib/services/command_processor.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/services/command_processor.dart
@@ -52,12 +52,15 @@ class CommandProcessor {
       // Remove ANSI escape sequences
       trimmed = trimmed.replaceAll(RegExp(r'\x1B\[[0-9;]*[A-Za-z]'), '');
 
-      // Determine line type and emit
-      _lineController.add(_processLine(trimmed));
+      // Determine line type and emit only if relevant
+      final processed = _processLine(trimmed);
+      if (processed != null) {
+        _lineController.add(processed);
+      }
     }
   }
 
-  ProcessedLine _processLine(String line) {
+  ProcessedLine? _processLine(String line) {
     // Check for RTM console response prefix
     if (line.startsWith('~>')) {
       final content = line.substring(2);
@@ -104,31 +107,15 @@ class CommandProcessor {
 
     // Check for log levels
     if (line.contains('<err>')) {
-      return ProcessedLine(
-        raw: line,
-        type: LineType.error,
-        content: line,
-      );
+      return null; // Ignore error logs
     } else if (line.contains('<wrn>')) {
-      return ProcessedLine(
-        raw: line,
-        type: LineType.warning,
-        content: line,
-      );
+      return null; // Ignore warning logs
     } else if (line.contains('<inf>')) {
-      return ProcessedLine(
-        raw: line,
-        type: LineType.info,
-        content: line,
-      );
+      return null; // Ignore info logs
     }
 
     // Default to raw line
-    return ProcessedLine(
-      raw: line,
-      type: LineType.other,
-      content: line,
-    );
+    return null; // Ignore any other lines
   }
 
   void dispose() {


### PR DESCRIPTION
## Summary
- ignore Zephyr logging in `CommandProcessor`
- note log filtering in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540bf81bac8325853fc536732327fe