### PR TITLE
Fix unprovisioned device list after provisioning

### DIFF
--- a/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
+++ b/bluetooth_mesh_hardware_provisioner/lib/blocs/provisioner_bloc.dart
@@ -577,7 +577,14 @@ class ProvisionerBloc extends Bloc<ProvisionerEvent, ProvisionerState> {
         adjusted.add(device);
       }
 
-      emit(state.copyWith(provisionedDevices: adjusted));
+      final provisionedUuids = adjusted.map((d) => d.uuid).toSet();
+      final filteredFound = Set<String>.from(state.foundUuids)
+        ..removeWhere(provisionedUuids.contains);
+
+      emit(state.copyWith(
+        provisionedDevices: adjusted,
+        foundUuids: filteredFound,
+      ));
       unawaited(_deviceCache.saveDevices(adjusted));
     } catch (e) {
       emit(state.copyWith(


### PR DESCRIPTION
## Summary
- filter out provisioned UUIDs when refreshing the device list so that recently provisioned devices disappear from the unprovisioned table

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685425b49d54832593da81f022faf814